### PR TITLE
Fix UI stuck

### DIFF
--- a/src/burp/Logs/LogTableModel.java
+++ b/src/burp/Logs/LogTableModel.java
@@ -18,8 +18,9 @@ public class LogTableModel extends AbstractTableModel {
     log.add(logEntry);
     if(filters.filter(logEntry)) {
       filteredLogs.add(logEntry);
+      int currRowIndex = filteredLogs.size() - 1;
+      fireTableRowsInserted(currRowIndex,currRowIndex);
     }
-    fireTableDataChanged();
   }
 
   public void filterLogs(Filters filters) {


### PR DESCRIPTION
Fix for this issue https://github.com/nccgroup/AutoRepeater/issues/84 

When a website sends a lot of request this error is generated:
```
java.lang.NullPointerException: Cannot read field "modelIndex" because "viewToModel[i]" is null
        at java.desktop/javax.swing.DefaultRowSorter.getViewToModelAsInts(DefaultRowSorter.java:753)
        at java.desktop/javax.swing.DefaultRowSorter.sort(DefaultRowSorter.java:581)
        at java.desktop/javax.swing.DefaultRowSorter.allRowsChanged(DefaultRowSorter.java:863)
        at java.desktop/javax.swing.JTable.notifySorter(JTable.java:4326)
        at java.desktop/javax.swing.JTable.sortedTableChanged(JTable.java:4186)
        at java.desktop/javax.swing.JTable.tableChanged(JTable.java:4463)
        at java.desktop/javax.swing.table.AbstractTableModel.fireTableChanged(AbstractTableModel.java:302)
        at java.desktop/javax.swing.table.AbstractTableModel.fireTableDataChanged(AbstractTableModel.java:204)
        at burp.Logs.LogTableModel.addLogEntry(LogTableModel.java:22)
        at burp.Logs.LogManager.lambda$addEntry$0(LogManager.java:40)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at burp.Zmnh.dispatchEvent(Unknown Source)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

It is because the entire UI get updated in every new entries, instead i switch it to update only the new added row.